### PR TITLE
fix queries with newlines, editable src blocks

### DIFF
--- a/ob-splunk.el
+++ b/ob-splunk.el
@@ -28,6 +28,11 @@
 
 ;;; Code:
 (require 'ob)
+(require 'url-util)
+
+;;; editable splunk src code blocks
+(unless (assoc "splunk" org-src-lang-modes)
+  (add-to-list 'org-src-lang-modes '("splunk" . funamental)))
 
 ;;; Splunk
 (defvar splunk-search-url nil
@@ -35,7 +40,7 @@
 
 (defun splunk-search (query-str)
   (if splunk-search-url
-      (browse-url (concat splunk-search-url "?q=" query-str))
+      (browse-url (concat splunk-search-url "?q=" (url-hexify-string query-str)))
     "`splunk-search-url` is not set."))
 
 ;;; Babel


### PR DESCRIPTION
queries which have line breaks, that would be valid in the splunk UI currently break due to the newlines in the `query-str` not being url-encoded, e.g.

```
index=blah
component=blah
"some log text"
```
Also since, this package does not include source code highlighting, labelling an org-mode `SRC` block with `splunk` means you can no longer edit it with `C-c C-'`. Associating it with `fundamental-mode` doesn't add the highlighting, but at leasts means we can still edit.